### PR TITLE
Fix home staying active in navbar closes #27

### DIFF
--- a/idb/src/Navigation.js
+++ b/idb/src/Navigation.js
@@ -15,7 +15,7 @@ export default class Navigation extends Component {
             </Navbar.Brand>
           </Navbar.Header>
           <Nav>
-            <LinkContainer to="/">
+            <LinkContainer to="/" exact={true}>
               <NavItem>
                 Home
               </NavItem>


### PR DESCRIPTION
Just added exact=true to the "Home" LinkContainer.