### PR TITLE
Setup frameworks for front end unit tests

### DIFF
--- a/idb/.babelrc
+++ b/idb/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["airbnb", "react", "env"]
+}

--- a/idb/package.json
+++ b/idb/package.json
@@ -24,10 +24,19 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "mocha --require ignore-styles --require babel-polyfill --require babel-core -w test/helpers/browser.js \"test/*.spec.js\"",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-airbnb": "^2.4.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-register": "^6.26.0",
+    "chai": "^4.1.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.18.0",
     "eslint-config-google": "^0.9.1",
     "eslint-config-standard": "^11.0.0",
@@ -35,6 +44,10 @@
     "eslint-plugin-node": "^6.0.0",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.7.0",
-    "eslint-plugin-standard": "^3.0.1"
+    "eslint-plugin-standard": "^3.0.1",
+    "ignore-styles": "^5.0.1",
+    "jsdom": "^11.6.2",
+    "mocha": "^5.0.1",
+    "react-addons-test-utils": "^15.6.2"
   }
 }

--- a/idb/test/Navigation.spec.js
+++ b/idb/test/Navigation.spec.js
@@ -1,0 +1,22 @@
+// Include in every spec file
+import React from 'react';
+import { expect } from 'chai';
+import Enzyme from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+Enzyme.configure({ adapter: new Adapter() });
+
+// Import necessary components for spec
+import Navigation from '../src/js/Navigation/Navigation';
+import { NavItem } from 'react-bootstrap';
+
+describe('Navigation Component', () => {
+  it('renders logo', () => {
+    const wrapper = shallow(<Navigation />)
+    expect(wrapper.find('img')).to.have.length(1)
+  })
+  it('renders 5 NavItems', () => {
+    const wrapper = shallow(<Navigation />)
+    expect(wrapper.find(NavItem)).to.have.length(5)
+  })
+})

--- a/idb/test/Splash.spec.js
+++ b/idb/test/Splash.spec.js
@@ -1,0 +1,26 @@
+// Include in every spec file
+import React from 'react';
+import { expect } from 'chai';
+import Enzyme from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+Enzyme.configure({ adapter: new Adapter() });
+
+// Import necessary components for spec
+import Splash from '../src/js/Splash/Splash';
+import Slider from 'react-slick';
+
+describe('Splash Page Component', () => {
+  it('renders header', () => {
+    const wrapper = shallow(<Splash />)
+    expect(wrapper.find('header').hasClass('App-header')).to.be.eql(true)
+  })
+  it('renders carousel', () => {
+    const wrapper = shallow(<Splash />)
+    expect(wrapper.find('.carousel-parent').exists()).to.eql(true)
+  })
+  it('renders images', () => {
+    const wrapper = shallow(<Splash />)
+    expect(wrapper.find('img')).to.have.length(3)
+  })
+})

--- a/idb/test/helpers/browser.js
+++ b/idb/test/helpers/browser.js
@@ -1,0 +1,34 @@
+require('babel-register')();
+
+var jsdom = require('jsdom');
+
+const { JSDOM } = jsdom;
+
+const { document } = (new JSDOM('')).window;
+global.document = document;
+
+var exposedProperties = ['window', 'navigator', 'document'];
+
+// global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+// Slider needs this
+window.matchMedia = window.matchMedia || function() {
+  return {
+      matches : false,
+      addListener : function() {},
+      removeListener: function() {}
+  };
+};
+
+global.navigator = {
+  userAgent: 'node.js'
+};
+
+documentRef = document;


### PR DESCRIPTION
## Description
- Setup Mocha along with Enzyme. Enzyme is a library for testing react components made by Airbnb.
- Added basic tests for Splash page
- Edited test script 
- Used babel for transpiling test code
- Using Chai for expect testing

References #110 